### PR TITLE
feat: add Google Drive storage for uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,15 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_FASTAPI_BASE_URL=http://localhost:8000
 
-# Storage (dev local; S3 later)
-NEXT_PUBLIC_USE_S3=false
+# Uploads (drive | s3 | local)
+UPLOAD_PROVIDER=drive
+
+# Google Drive credentials (required when UPLOAD_PROVIDER=drive)
+GOOGLE_SERVICE_ACCOUNT_EMAIL=
+GOOGLE_PRIVATE_KEY=
+GOOGLE_DRIVE_FOLDER_ID=
+
+# S3 credentials (required when UPLOAD_PROVIDER=s3)
 AWS_S3_BUCKET=
 AWS_S3_REGION=
 AWS_ACCESS_KEY_ID=

--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ Create `.env.local` using `.env.example` as a reference. Required variables:
 ```
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_FASTAPI_BASE_URL=http://localhost:8000
-NEXT_PUBLIC_USE_S3=false
 DATABASE_URL=file:./dev.db
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...
 ADMIN_EMAILS=founder@example.com,admin@example.com
+
+# Uploads
+UPLOAD_PROVIDER=drive # drive | s3 | local
+GOOGLE_SERVICE_ACCOUNT_EMAIL=...
+GOOGLE_PRIVATE_KEY="..."
+GOOGLE_DRIVE_FOLDER_ID=...
 ```
 
 ## Clerk Setup
@@ -43,6 +48,8 @@ Set `NEXT_PUBLIC_FASTAPI_BASE_URL` to your FastAPI service URL.
 
 ## Uploads
 
-User photos are saved under `public/uploads/{userId}/` in development. When `NEXT_PUBLIC_USE_S3=true` the upload handler is a placeholder for future S3 integration.
+By default user photos are uploaded to a Google Drive folder using a service account. Provide the Drive credentials and `UPLOAD_PROVIDER=drive` in your `.env.local`.
+
+To save files locally use `UPLOAD_PROVIDER=local`, which writes to `public/uploads/{userId}/`. For future S3 support set `UPLOAD_PROVIDER=s3` and supply the AWS credentials.
 
 This repository is a simplified skeleton; additional UI polish, rate limiting, and S3 support can be added.

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,23 +1,66 @@
 import fs from 'fs/promises'
 import path from 'path'
+import { Readable } from 'stream'
+import { google, drive_v3 } from 'googleapis'
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
 import { v4 as uuid } from 'uuid'
 
-const useS3 = process.env.USE_S3 === 'true'
+// Determine upload provider: 'drive' (default), 's3', or 'local'
+const provider = process.env.UPLOAD_PROVIDER || 'drive'
 const localDir = path.join(process.cwd(), 'public', 'uploads')
+
+let drive: drive_v3.Drive | null = null
+if (provider === 'drive') {
+  const auth = new google.auth.JWT(
+    process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+    undefined,
+    (process.env.GOOGLE_PRIVATE_KEY || '').replace(/\\n/g, '\n'),
+    ['https://www.googleapis.com/auth/drive.file']
+  )
+  drive = google.drive({ version: 'v3', auth })
+}
 
 export async function saveBuffer(buffer: Buffer, userId: string, ext: string) {
   const filename = `${uuid()}.${ext}`
-  if (useS3) {
+
+  if (provider === 's3') {
     const client = new S3Client({ region: process.env.AWS_S3_REGION })
     const Key = `${userId}/${filename}`
-    await client.send(new PutObjectCommand({ Bucket: process.env.AWS_S3_BUCKET!, Key, Body: buffer }))
+    await client.send(
+      new PutObjectCommand({ Bucket: process.env.AWS_S3_BUCKET!, Key, Body: buffer })
+    )
     return `https://${process.env.AWS_S3_BUCKET}.s3.${process.env.AWS_S3_REGION}.amazonaws.com/${Key}`
-  } else {
+  }
+
+  if (provider === 'local') {
     const dir = path.join(localDir, userId)
     await fs.mkdir(dir, { recursive: true })
     const filePath = path.join(dir, filename)
     await fs.writeFile(filePath, buffer)
     return `/uploads/${userId}/${filename}`
   }
+
+  // Default: upload to Google Drive
+  if (!drive) throw new Error('Google Drive not configured')
+  const fileMeta = {
+    name: filename,
+    parents: [process.env.GOOGLE_DRIVE_FOLDER_ID!],
+  }
+  const media = {
+    mimeType: `image/${ext}`,
+    body: Readable.from(buffer),
+  }
+  const res = await drive.files.create({
+    requestBody: fileMeta,
+    media,
+    fields: 'id',
+  })
+  const fileId = res.data.id
+  if (!fileId) throw new Error('Failed to upload to Google Drive')
+
+  await drive.permissions.create({
+    fileId,
+    requestBody: { role: 'reader', type: 'anyone' },
+  })
+  return `https://drive.google.com/uc?export=download&id=${fileId}`
 }

--- a/package.json
+++ b/package.json
@@ -13,24 +13,26 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "@prisma/client": "5.10.2",
-    "next": "14.0.4",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "zod": "^3.22.2",
-    "@clerk/nextjs": "^4.27.5",
     "@aws-sdk/client-s3": "^3.482.0",
     "@aws-sdk/s3-request-presigner": "^3.482.0",
-    "clsx": "^2.0.0",
-    "tailwindcss": "^3.4.1",
-    "postcss": "^8.4.35",
+    "@clerk/nextjs": "^4.27.5",
+    "@prisma/client": "5.10.2",
     "autoprefixer": "^10.4.17",
+    "clsx": "^2.0.0",
     "csv-parse": "^5.5.1",
-    "uuid": "^9.0.0",
     "framer-motion": "^10.16.4",
-    "lucide-react": "^0.307.0"
+    "googleapis": "^131.0.0",
+    "lucide-react": "^0.307.0",
+    "next": "14.0.4",
+    "postcss": "^8.4.35",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.1",
+    "uuid": "^9.0.0",
+    "zod": "^3.22.2"
   },
   "devDependencies": {
+    "@types/react": "19.1.11",
     "prisma": "5.10.2",
     "tsx": "4.7.0",
     "typescript": "5.3.3"


### PR DESCRIPTION
## Summary
- support Google Drive as default upload provider with service account integration
- document upload provider configuration and credentials
- add googleapis dependency for Drive uploads

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9410a648325baf2629fffd61f33